### PR TITLE
chore: update Stripe setup instructions to use placeholder values

### DIFF
--- a/docs/STRIPE_SETUP_INSTRUCTIONS.md
+++ b/docs/STRIPE_SETUP_INSTRUCTIONS.md
@@ -27,8 +27,8 @@ firebase functions:config:get
 # Resultado:
 # {
 #   "stripe": {
-#     "secret_key": "sk_test_51Rj4lZPY7RDrzGXC...",
-#     "webhook_secret": "whsec_S109jNBpeAZ8GaC3bzjDkHeMPKhWh4eb"
+#     "secret_key": "<secret_key>",
+#     "webhook_secret": "<webhook_secret>"
 #   }
 # }
 ```


### PR DESCRIPTION
- Replaced actual secret keys in the documentation with placeholder values for security and clarity.
- This change ensures sensitive information is not exposed in the setup instructions.